### PR TITLE
fixed case-sensitive import collision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ go:
   - 1.8
   - master
 install:
-  - go get github.com/Sirupsen/logrus
+  - go get github.com/sirupsen/logrus

--- a/discordrus.go
+++ b/discordrus.go
@@ -1,12 +1,13 @@
 package discordrus
 
 import (
-	"github.com/Sirupsen/logrus"
-	"encoding/json"
-	"strings"
-	"net/http"
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/discordrus_test.go
+++ b/discordrus_test.go
@@ -1,13 +1,14 @@
 package discordrus
 
 import (
-	"github.com/Sirupsen/logrus"
-	"os"
-	"testing"
 	"bytes"
 	"net/http"
+	"os"
 	"strings"
+	"testing"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -123,7 +124,6 @@ func TestMaxLengths(t *testing.T) {
 			json:               "{\"embeds\":[{\"author\":{\"name\":\"A\"},\"description\":\"" + strings.Repeat("A", maxDescriptionChars+1) + "\",\"fields\":[{\"name\":\"A\",\"value\":\"A\"}],\"title\":\"A\"}],\"username\":\"AA\"}",
 			expectedStatusCode: 400,
 		},
-
 	}
 
 	for _, test := range tests {

--- a/levels.go
+++ b/levels.go
@@ -1,7 +1,7 @@
 package discordrus
 
 import (
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // LevelColors is a struct of the possible colors used in Discord color format (0x[RGB] converted to int)

--- a/levels_test.go
+++ b/levels_test.go
@@ -1,9 +1,10 @@
 package discordrus
 
 import (
-	"testing"
-	"github.com/Sirupsen/logrus"
 	"reflect"
+	"testing"
+
+	"github.com/sirupsen/logrus"
 )
 
 // TestAllLevels ensures that logrus' AllLevels has not changed
@@ -71,16 +72,16 @@ func TestLevelColor(t *testing.T) {
 		Panic: 5,
 		Fatal: 6,
 	}
-	
+
 	// Test default colors
 	expectedDefaultColorForError := DefaultLevelColors.Error
 	if expectedDefaultColorForError != DefaultLevelColors.LevelColor(logrus.ErrorLevel) {
 		t.Error("Error color for default LevelColor is not as expected")
 	}
-	
+
 	// Test custom colors
 	expectedCustomColorForPanic := customLevelColors.Panic
 	if expectedCustomColorForPanic != customLevelColors.LevelColor(logrus.PanicLevel) {
 		t.Error("Panic color for custom LevelColor is not as expected")
-	}	
+	}
 }


### PR DESCRIPTION
changed 'Sirupsen/logrus' to the new lowercase 'sirupsen/logrus' to avoid the case-sensitive import collision