### PR TITLE
Add support for timestamp timezone locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # discordrus | a [Discord](https://discordapp.com/) hook for [Logrus](https://github.com/Sirupsen/logrus) <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/> [![Travis CI](https://api.travis-ci.org/kz/discordrus.svg?branch=master)](https://travis-ci.org/kz/discordrus) [![GoDoc](https://godoc.org/github.com/puddingfactory/logentrus?status.svg)](https://godoc.org/github.com/kz/discordrus)
 
-**Current version:** v1.0.1
+**Current version:** v1.0.2
 
 ![Screenshot of discordrus in action](http://i.imgur.com/zvDNDjV.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # discordrus | a [Discord](https://discordapp.com/) hook for [Logrus](https://github.com/Sirupsen/logrus) <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/> [![Travis CI](https://api.travis-ci.org/kz/discordrus.svg?branch=master)](https://travis-ci.org/kz/discordrus) [![GoDoc](https://godoc.org/github.com/puddingfactory/logentrus?status.svg)](https://godoc.org/github.com/kz/discordrus)
 
-**Current version:** v1.0.2
+**Current version:** v1.1.0
 
 ![Screenshot of discordrus in action](http://i.imgur.com/zvDNDjV.png)
 
@@ -21,11 +21,8 @@ Below is an example of how this package may be used. The options below are used 
 package main
 
 import (
-	"os"
-	"strings"
-	"time"
-	
 	"github.com/sirupsen/logrus"
+	"os"
 	"github.com/kz/discordrus"
 )
 
@@ -34,35 +31,18 @@ func init() {
 	logrus.SetOutput(os.Stderr)
 	logrus.SetLevel(logrus.DebugLevel)
 
-	// Log timestamps in UTC
-	timeString := ""
-
-	timestampLocale, err := time.LoadLocation("UTC") // e.g. "America/New_York"
-	if err != nil {
-		logrus.WithError(err).Debugf("Unable to determine timestampLocale, defaulting to local runtime")
-
-		timeString = time.Now().String()
-	} else {
-		logrus.WithField("timestampLocale", timestampLocale).Debugf("Found custom logging locality")
-
-		timeString = time.Now().In(timestampLocale).String()
-	}
-
-	// timeZoneTokens => [2017-12-23] [11:45:53.0703314] [-0000] [UTC]
-	timeZoneToken := strings.Split(timeString, " ")[3]
-
-	timeStampFormat := "Jan 2 15:04:05.00000 " + timeZoneToken
-
 	logrus.AddHook(discordrus.NewHook(
 		// Use environment variable for security reasons
 		os.Getenv("DISCORDRUS_WEBHOOK_URL"),
 		// Set minimum level to DebugLevel to receive all log entries
 		logrus.DebugLevel,
 		&discordrus.Opts{
-			Username:            "",
-			Author:              "",    // Setting this to a non-empty string adds the author text to the message header
-			DisableInlineFields: false, // If set to true, fields will not appear in columns ("inline")
-			EnableCustomColors:  true,  // If set to true, the below CustomLevelColors will apply
+			Username:           "Test Username",
+			Author:             "",                         // Setting this to a non-empty string adds the author text to the message header
+			DisableTimestamp:   false,                      // Setting this to true will disable timestamps from appearing in the footer
+			TimestampFormat:    "Jan 2 15:04:05.00000 MST", // The timestamp takes this format; if it is unset, it will take logrus' default format
+			TimestampLocale:    nil,                        // The timestamp uses this locale; if it is unset, it will use time.Local
+			EnableCustomColors: true,                       // If set to true, the below CustomLevelColors will apply
 			CustomLevelColors: &discordrus.LevelColors{
 				Debug: 10170623,
 				Info:  3581519,
@@ -71,9 +51,7 @@ func init() {
 				Panic: 13631488,
 				Fatal: 13631488,
 			},
-			DisableTimestamp: false,           // Setting this to true will disable timestamps from appearing in the footer
-			TimestampFormat:  timeStampFormat, // The timestamp takes this format; if it is unset, it will take logrus' default format
-			TimestampLocale:  nil,             // nil == time.Local, time.UTC, time.LoadLocation("America/New_York"), etc
+			DisableInlineFields: false, // If set to true, fields will not appear in columns ("inline")
 		},
 	))
 }
@@ -89,13 +67,12 @@ Option | Description | Default | Valid options
 --- | --- | --- | ---
 Username | Replaces the default username of the webhook bot for the sent message only | Username unchanged | Any non-empty string (2-32 chars. inclusive)
 Author | Adds an author field to the header if set | Author not set | Any non-empty string (1-256 chars inclusive)
-DisableInlineFields | Inline means whether Discord will display the field in a column (with maximum three columns to a row). Setting this to `true` will cause Discord to display the field in its own row. | false | bool
-EnableCustomColors | Specifies whether the `CustomLevelColors` opt value should be used instead of `discordrus.DefaultLevelColors`. If `true`, `CustomLevelColors` must be specified (or all colors will be set to the nil value of `0`, therefore displayed as white) | false | bool
-CustomLevelColors | Replaces `discordrus.DefaultLevelColors`. All fields must be entered or they will default to the nil value of `0`. | Pointer to struct instance of `discordrus.LevelColors` 
+DisableInlineFields | Inline means whether Discord will display the field in a column (with maximum three columns to a row). Setting this to `true` will cause Discord to display the field in its own row. | false | bool 
 DisableTimestamp | Specifies whether the timestamp in the footer should be disabled | false | bool
-TimestampFormat | Change the timestamp format | logrus's default time format | `"Jan 2 15:04:05"`, or any format accepted by Golang
+TimestampFormat | Change the timestamp format | logrus's default time format | `"Jan 2 15:04:05.00000 MST"`, or any format accepted by Golang
 TimestampLocale | Change the timestamp locale | `nil` | nil == time.Local, time.UTC, time.LoadLocation("America/New_York"), etc
-
+EnableCustomColors | Specifies whether the `CustomLevelColors` opt value should be used instead of `discordrus.DefaultLevelColors`. If `true`, `CustomLevelColors` must be specified (or all colors will be set to the nil value of `0`, therefore displayed as white) | false | bool
+CustomLevelColors | Replaces `discordrus.DefaultLevelColors`. All fields must be entered or they will default to the nil value of `0`. | Pointer to struct instance of `discordrus.LevelColors`
 	
 In addition to the above character count constraints, Discord has a maximum of 25 fields with their name and value limits being 256 and 1024 respectively. Furthermore, the description (i.e., logrus' error message) must be a maximum of 2048. All of these constraints, including the option constraints above, will automatically be truncated with no further action required.
  

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ package main
 
 import (
     "os"
-	"github.com/Sirupsen/logrus"
+    "time"
+    "strings"
+    
+	"github.com/sirupsen/logrus"
 	"github.com/kz/discordrus"
 )
 
@@ -30,27 +33,47 @@ func init() {
 	logrus.SetFormatter(&logrus.TextFormatter{})
 	logrus.SetOutput(os.Stderr)
 	logrus.SetLevel(logrus.DebugLevel)
+	
+	// Log timestamps in UTC
+	timeString := ""
+	
+	timestampLocale, err := time.LoadLocation("UTC") // e.g. "America/New_York"
+	if err != nil {
+		logrus.WithError(err).Debugf("Unable to determine timestampLocale, defaulting to local runtime")
+		
+		timeString = time.Now().String()
+	} else {
+        logrus.WithField("timestampLocale", timestampLocale).Debugf("Found custom logging locality")
+
+        timeString = time.Now().In(timestampLocale).String()
+    }
+	
+	// timeZoneTokens => [2017-12-23] [11:45:53.0703314] [-0000] [UTC]
+    timeZoneToken := strings.Split(timeString, " ")[3]
+
+    timeStampFormat := "Jan 2 15:04:05.00000 " + timeZoneToken
 
 	logrus.AddHook(discordrus.NewHook(
 		// Use environment variable for security reasons
 		os.Getenv("DISCORDRUS_WEBHOOK_URL"),
 		// Set minimum level to DebugLevel to receive all log entries
 		logrus.DebugLevel,
-		&discordrus.Opts{
-			Username: "Test Username",
-			Author: "", // Setting this to a non-empty string adds the author text to the message header
-			DisableTimestamp: false, // Setting this to true will disable timestamps from appearing in the footer
-			TimestampFormat: "Jan 2 15:04:05.00000", // The timestamp takes this format; if it is unset, it will take logrus' default format
-			EnableCustomColors: true, // If set to true, the below CustomLevelColors will apply
-			CustomLevelColors: &discordrus.LevelColors{
-				Debug: 10170623,
-				Info:  3581519,
-				Warn:  14327864,
-				Error: 13631488,
-				Panic: 13631488,
-				Fatal: 13631488,
-			},
-			DisableInlineFields: false, // If set to true, fields will not appear in columns ("inline")
+        &discordrus.Opts{
+            Username:            "",
+            Author:              "",    // Setting this to a non-empty string adds the author text to the message header
+            DisableInlineFields: false, // If set to true, fields will not appear in columns ("inline")
+            EnableCustomColors:  true,  // If set to true, the below CustomLevelColors will apply
+            CustomLevelColors: &discordrus.LevelColors{
+                Debug: 10170623,
+                Info:  3581519,
+                Warn:  14327864,
+                Error: 13631488,
+                Panic: 13631488,
+                Fatal: 13631488,
+            },
+            DisableTimestamp: false,           // Setting this to true will disable timestamps from appearing in the footer
+            TimestampFormat:  timeStampFormat, // The timestamp takes this format; if it is unset, it will take logrus' default format
+            TimestampLocale:  nil,             // nil == time.Local, time.UTC, time.LoadLocation("America/New_York"), etc
 		},
 	))
 }
@@ -66,11 +89,13 @@ Option | Description | Default | Valid options
 --- | --- | --- | ---
 Username | Replaces the default username of the webhook bot for the sent message only | Username unchanged | Any non-empty string (2-32 chars. inclusive)
 Author | Adds an author field to the header if set | Author not set | Any non-empty string (1-256 chars inclusive)
-DisableInlineFields | Inline means whether Discord will display the field in a column (with maximum three columns to a row). Setting this to `true` will cause Discord to display the field in its own row. | false | bool 
+DisableInlineFields | Inline means whether Discord will display the field in a column (with maximum three columns to a row). Setting this to `true` will cause Discord to display the field in its own row. | false | bool
+EnableCustomColors | Specifies whether the `CustomLevelColors` opt value should be used instead of `discordrus.DefaultLevelColors`. If `true`, `CustomLevelColors` must be specified (or all colors will be set to the nil value of `0`, therefore displayed as white) | false | bool
+CustomLevelColors | Replaces `discordrus.DefaultLevelColors`. All fields must be entered or they will default to the nil value of `0`. | Pointer to struct instance of `discordrus.LevelColors` 
 DisableTimestamp | Specifies whether the timestamp in the footer should be disabled | false | bool
 TimestampFormat | Change the timestamp format | logrus's default time format | `"Jan 2 15:04:05"`, or any format accepted by Golang
-EnableCustomColors | Specifies whether the `CustomLevelColors` opt value should be used instead of `discordrus.DefaultLevelColors`. If `true`, `CustomLevelColors` must be specified (or all colors will be set to the nil value of `0`, therefore displayed as white) | false | bool
-CustomLevelColors | Replaces `discordrus.DefaultLevelColors`. All fields must be entered or they will default to the nil value of `0`. | Pointer to struct instance of `discordrus.LevelColors`
+TimestampLocale | Change the timestamp locale | `nil` | nil == time.Local, time.UTC, time.LoadLocation("America/New_York"), etc
+
 	
 In addition to the above character count constraints, Discord has a maximum of 25 fields with their name and value limits being 256 and 1024 respectively. Furthermore, the description (i.e., logrus' error message) must be a maximum of 2048. All of these constraints, including the option constraints above, will automatically be truncated with no further action required.
  

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Below is an example of how this package may be used. The options below are used 
 package main
 
 import (
-    "os"
-    "time"
-    "strings"
-    
+	"os"
+	"strings"
+	"time"
+	
 	"github.com/sirupsen/logrus"
 	"github.com/kz/discordrus"
 )
@@ -33,47 +33,47 @@ func init() {
 	logrus.SetFormatter(&logrus.TextFormatter{})
 	logrus.SetOutput(os.Stderr)
 	logrus.SetLevel(logrus.DebugLevel)
-	
+
 	// Log timestamps in UTC
 	timeString := ""
-	
+
 	timestampLocale, err := time.LoadLocation("UTC") // e.g. "America/New_York"
 	if err != nil {
 		logrus.WithError(err).Debugf("Unable to determine timestampLocale, defaulting to local runtime")
-		
+
 		timeString = time.Now().String()
 	} else {
-        logrus.WithField("timestampLocale", timestampLocale).Debugf("Found custom logging locality")
+		logrus.WithField("timestampLocale", timestampLocale).Debugf("Found custom logging locality")
 
-        timeString = time.Now().In(timestampLocale).String()
-    }
-	
+		timeString = time.Now().In(timestampLocale).String()
+	}
+
 	// timeZoneTokens => [2017-12-23] [11:45:53.0703314] [-0000] [UTC]
-    timeZoneToken := strings.Split(timeString, " ")[3]
+	timeZoneToken := strings.Split(timeString, " ")[3]
 
-    timeStampFormat := "Jan 2 15:04:05.00000 " + timeZoneToken
+	timeStampFormat := "Jan 2 15:04:05.00000 " + timeZoneToken
 
 	logrus.AddHook(discordrus.NewHook(
 		// Use environment variable for security reasons
 		os.Getenv("DISCORDRUS_WEBHOOK_URL"),
 		// Set minimum level to DebugLevel to receive all log entries
 		logrus.DebugLevel,
-        &discordrus.Opts{
-            Username:            "",
-            Author:              "",    // Setting this to a non-empty string adds the author text to the message header
-            DisableInlineFields: false, // If set to true, fields will not appear in columns ("inline")
-            EnableCustomColors:  true,  // If set to true, the below CustomLevelColors will apply
-            CustomLevelColors: &discordrus.LevelColors{
-                Debug: 10170623,
-                Info:  3581519,
-                Warn:  14327864,
-                Error: 13631488,
-                Panic: 13631488,
-                Fatal: 13631488,
-            },
-            DisableTimestamp: false,           // Setting this to true will disable timestamps from appearing in the footer
-            TimestampFormat:  timeStampFormat, // The timestamp takes this format; if it is unset, it will take logrus' default format
-            TimestampLocale:  nil,             // nil == time.Local, time.UTC, time.LoadLocation("America/New_York"), etc
+		&discordrus.Opts{
+			Username:            "",
+			Author:              "",    // Setting this to a non-empty string adds the author text to the message header
+			DisableInlineFields: false, // If set to true, fields will not appear in columns ("inline")
+			EnableCustomColors:  true,  // If set to true, the below CustomLevelColors will apply
+			CustomLevelColors: &discordrus.LevelColors{
+				Debug: 10170623,
+				Info:  3581519,
+				Warn:  14327864,
+				Error: 13631488,
+				Panic: 13631488,
+				Fatal: 13631488,
+			},
+			DisableTimestamp: false,           // Setting this to true will disable timestamps from appearing in the footer
+			TimestampFormat:  timeStampFormat, // The timestamp takes this format; if it is unset, it will take logrus' default format
+			TimestampLocale:  nil,             // nil == time.Local, time.UTC, time.LoadLocation("America/New_York"), etc
 		},
 	))
 }

--- a/discordrus.go
+++ b/discordrus.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"time"
 )
 
 const (
@@ -37,6 +38,8 @@ type Opts struct {
 	DisableTimestamp bool
 	// TimestampFormat specifies a custom format for the footer
 	TimestampFormat string
+	// TimestampLocale specifies a custom locale for the timestamp
+	TimestampLocale *time.Location
 }
 
 // Hook is a hook to send logs to Discord
@@ -127,6 +130,9 @@ func (hook *Hook) parseToJson(entry *logrus.Entry) (*[]byte, error) {
 
 	// Add footer to embed
 	if !hook.Opts.DisableTimestamp {
+		if hook.Opts.TimestampLocale != nil {
+			entry.Time = entry.Time.In(hook.Opts.TimestampLocale)
+		}
 		timestamp := ""
 		if hook.Opts.TimestampFormat != "" {
 			timestamp = entry.Time.Format(hook.Opts.TimestampFormat)

--- a/discordrus_test.go
+++ b/discordrus_test.go
@@ -26,6 +26,7 @@ func init() {
 			Author:             "",                     // Setting this to a non-empty string adds the author text to the message header
 			DisableTimestamp:   false,                  // Setting this to true will disable timestamps from appearing in the footer
 			TimestampFormat:    "Jan 2 15:04:05.00000", // The timestamp takes this format; if it is unset, it will take logrus' default format
+			TimestampLocale:    time.UTC,               // The timestamp takes it's timezone from the provided locale
 			EnableCustomColors: true,                   // If set to true, the below CustomLevelColors will apply
 			CustomLevelColors: &LevelColors{
 				Debug: 10170623,

--- a/discordrus_test.go
+++ b/discordrus_test.go
@@ -23,11 +23,11 @@ func init() {
 		logrus.DebugLevel,
 		&Opts{
 			Username:           "Test Username",
-			Author:             "",                     // Setting this to a non-empty string adds the author text to the message header
-			DisableTimestamp:   false,                  // Setting this to true will disable timestamps from appearing in the footer
-			TimestampFormat:    "Jan 2 15:04:05.00000", // The timestamp takes this format; if it is unset, it will take logrus' default format
-			TimestampLocale:    time.UTC,               // The timestamp takes it's timezone from the provided locale
-			EnableCustomColors: true,                   // If set to true, the below CustomLevelColors will apply
+			Author:             "",                         // Setting this to a non-empty string adds the author text to the message header
+			DisableTimestamp:   false,                      // Setting this to true will disable timestamps from appearing in the footer
+			TimestampFormat:    "Jan 2 15:04:05.00000 MST", // The timestamp takes this format; if it is unset, it will take logrus' default format
+			TimestampLocale:    nil,                        // The timestamp uses this locale; if it is unset, it will use time.Local
+			EnableCustomColors: true,                       // If set to true, the below CustomLevelColors will apply
 			CustomLevelColors: &LevelColors{
 				Debug: 10170623,
 				Info:  3581519,


### PR DESCRIPTION
Added support for displaying timestamps according to a timezone locale.  This change should be fully backwards compatible with existing implementations of this library.

The Opts struct has a new field, TimestampLocale:
```go
type Opts struct {
	// Original fields remain unaltered
	// TimestampLocale specifies a custom locale for the timestamp
	TimestampLocale *time.Location
}
```

In addition, the `parseToJson` method was updated to support the Opts struct change:

```go
func (hook *Hook) parseToJson(entry *logrus.Entry) (*[]byte, error) {
	// Beginning unchanged

	// Add footer to embed
	if !hook.Opts.DisableTimestamp {
		if hook.Opts.TimestampLocale != nil {
			entry.Time = entry.Time.In(hook.Opts.TimestampLocale)
		}
	// Remainder unchanged
	}

	// Remainder unchanged
}
```